### PR TITLE
RFC: required propTypes no longer generate null and undefined

### DIFF
--- a/plugin/default-plugins/playground/frontend/components/controls/ArrayControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/ArrayControl/index.js
@@ -57,9 +57,9 @@ const ArrayControl = (props) => {
   );
 };
 
-ArrayControl.randomValue = (propTypeData, required) => {
-  const canBeNull = !required;
-  const canBeUndefined = !required;
+ArrayControl.randomValue = (propTypeData) => {
+  const canBeNull = !propTypeData.required;
+  const canBeUndefined = !propTypeData.required;
   // Restrict random arrays to a length between 0 and 4 elements
   const min = 0;
   const max = 4;

--- a/plugin/default-plugins/playground/frontend/components/controls/ArrayControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/ArrayControl/index.js
@@ -57,17 +57,23 @@ const ArrayControl = (props) => {
   );
 };
 
-ArrayControl.randomValue = (props) => {
-  const canBeNull = true;
-  const canBeUndefined = true;
+ArrayControl.randomValue = (propTypeData, required) => {
+  const canBeNull = !required;
+  const canBeUndefined = !required;
+  // Restrict random arrays to a length between 0 and 4 elements
   const min = 0;
   const max = 4;
   const size = Math.floor(Math.random() * (max - min + 1)) + min;
   const rangeArray = range(min, size);
-  const propTypeData = props.value || props.type && props.type.value; // TODO clean up
-  const control = getControl(propTypeData);
+  // Get the prop type data of the insides of the array
+  const innerPropTypeData =
+    propTypeData.value
+    || propTypeData.type
+    && propTypeData.type.value; // TODO clean up
+  const control = getControl(innerPropTypeData);
 
-  const value = rangeArray.map(() => control.type.randomValue(propTypeData));
+  // Generate a random value for each propType in the array
+  const value = rangeArray.map(() => control.type.randomValue(innerPropTypeData));
 
   return valueOrNullOrUndefined(value, canBeNull, canBeUndefined);
 };

--- a/plugin/default-plugins/playground/frontend/components/controls/BooleanControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/BooleanControl/index.js
@@ -29,7 +29,7 @@ const BooleanControl = (props) => {
           label: 'false',
         },
       ]}
-      onRandomClick={() => onUpdate({ value: BooleanControl.randomValue(props) })}
+      onRandomClick={() => onUpdate({ value: BooleanControl.randomValue(props, props.required) })}
     />
   );
 };
@@ -37,11 +37,9 @@ const BooleanControl = (props) => {
 /**
  * Generates a random boolean value
  */
-BooleanControl.randomValue = ({ random = {} }) => {
-  const {
-    canBeNull = true,
-    canBeUndefined = true,
-  } = random;
+BooleanControl.randomValue = (props = {}, required) => {
+  const canBeNull = !required;
+  const canBeUndefined = !required;
   const value = Math.random() >= 0.5;
   return valueOrNullOrUndefined(value, canBeNull, canBeUndefined);
 };

--- a/plugin/default-plugins/playground/frontend/components/controls/BooleanControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/BooleanControl/index.js
@@ -37,9 +37,9 @@ const BooleanControl = (props) => {
 /**
  * Generates a random boolean value
  */
-BooleanControl.randomValue = (props = {}, required) => {
-  const canBeNull = !required;
-  const canBeUndefined = !required;
+BooleanControl.randomValue = (props) => {
+  const canBeNull = !props.required;
+  const canBeUndefined = !props.required;
   const value = Math.random() >= 0.5;
   return valueOrNullOrUndefined(value, canBeNull, canBeUndefined);
 };

--- a/plugin/default-plugins/playground/frontend/components/controls/IntegerControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/IntegerControl/index.js
@@ -19,7 +19,7 @@ const IntegerControl = (props) => {
       value={value}
       isNested={isNested}
       onChange={(event) => onUpdate({ value: parseInt(event.target.value, 10) })}
-      onRandomClick={() => onUpdate({ value: IntegerControl.randomValue(props) })}
+      onRandomClick={() => onUpdate({ value: IntegerControl.randomValue(props, props.required) })}
     />
   );
 };
@@ -27,14 +27,14 @@ const IntegerControl = (props) => {
 /**
  * Generates a random integer
  */
-IntegerControl.randomValue = ({ random = {} }) => {
+IntegerControl.randomValue = (props, required) => {
   const {
-    canBeNull = true,
-    canBeUndefined = true,
     min = Number.MAX_SAFE_INTEGER,
     max = Number.MIN_SAFE_INTEGER,
     step = 1,
-  } = random;
+  } = props;
+  const canBeNull = !required;
+  const canBeUndefined = !required;
   let number;
   do {
     number = Math.floor(Math.random() * (max - min + 1)) + min;

--- a/plugin/default-plugins/playground/frontend/components/controls/IntegerControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/IntegerControl/index.js
@@ -27,14 +27,14 @@ const IntegerControl = (props) => {
 /**
  * Generates a random integer
  */
-IntegerControl.randomValue = (props, required) => {
+IntegerControl.randomValue = (props) => {
   const {
     min = Number.MAX_SAFE_INTEGER,
     max = Number.MIN_SAFE_INTEGER,
     step = 1,
   } = props;
-  const canBeNull = !required;
-  const canBeUndefined = !required;
+  const canBeNull = !props.required;
+  const canBeUndefined = !props.required;
   let number;
   do {
     number = Math.floor(Math.random() * (max - min + 1)) + min;

--- a/plugin/default-plugins/playground/frontend/components/controls/ObjectControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/ObjectControl/index.js
@@ -14,7 +14,7 @@ import Label from '../../common/Label';
 
 import styles from './styles.css';
 
-const ObjectControl = ({ label, propTypeData, value, onUpdate, isNested }) => {
+const ObjectControl = ({ label, propTypeData, value, onUpdate, isNested, required }) => {
   const updatePropertyValues = (values) => {
     onUpdate({ value: values });
   };
@@ -38,7 +38,9 @@ const ObjectControl = ({ label, propTypeData, value, onUpdate, isNested }) => {
         <Label
           text={label}
           isNested={isNested}
-          onRandomClick={() => onUpdate({ value: ObjectControl.randomValue(propTypeData) })}
+          onRandomClick={() => onUpdate({
+            value: ObjectControl.randomValue(propTypeData, required),
+          })}
         />
       ) : null}
       <div className={controlWrapperClassName}>
@@ -48,15 +50,15 @@ const ObjectControl = ({ label, propTypeData, value, onUpdate, isNested }) => {
   );
 };
 
-ObjectControl.randomValue = (propTypeData) => {
-  const canBeNull = true;
-  const canBeUndefined = true;
+ObjectControl.randomValue = (propTypeData, required) => {
+  const canReallyBeNull = !required;
+  const canReallyBeUndefined = !required;
   const normalizedPropsWithControls = mapValues(propTypeData.value, (prop) => {
     prop.control = getControl(prop); // eslint-disable-line no-param-reassign
     return prop;
   });
   const value = randomValues(normalizedPropsWithControls);
-  return valueOrNullOrUndefined(value, canBeNull, canBeUndefined);
+  return valueOrNullOrUndefined(value, canReallyBeNull, canReallyBeUndefined);
 };
 
 export default ObjectControl;

--- a/plugin/default-plugins/playground/frontend/components/controls/ObjectControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/ObjectControl/index.js
@@ -50,9 +50,9 @@ const ObjectControl = ({ label, propTypeData, value, onUpdate, isNested, require
   );
 };
 
-ObjectControl.randomValue = (propTypeData, required) => {
-  const canReallyBeNull = !required;
-  const canReallyBeUndefined = !required;
+ObjectControl.randomValue = (propTypeData) => {
+  const canReallyBeNull = !propTypeData.required;
+  const canReallyBeUndefined = !propTypeData.required;
   const normalizedPropsWithControls = mapValues(propTypeData.value, (prop) => {
     prop.control = getControl(prop); // eslint-disable-line no-param-reassign
     return prop;

--- a/plugin/default-plugins/playground/frontend/components/controls/ObjectControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/ObjectControl/index.js
@@ -51,14 +51,14 @@ const ObjectControl = ({ label, propTypeData, value, onUpdate, isNested, require
 };
 
 ObjectControl.randomValue = (propTypeData) => {
-  const canReallyBeNull = !propTypeData.required;
-  const canReallyBeUndefined = !propTypeData.required;
+  const canBeNull = !propTypeData.required;
+  const canBeUndefined = !propTypeData.required;
   const normalizedPropsWithControls = mapValues(propTypeData.value, (prop) => {
     prop.control = getControl(prop); // eslint-disable-line no-param-reassign
     return prop;
   });
   const value = randomValues(normalizedPropsWithControls);
-  return valueOrNullOrUndefined(value, canReallyBeNull, canReallyBeUndefined);
+  return valueOrNullOrUndefined(value, canBeNull, canBeUndefined);
 };
 
 export default ObjectControl;

--- a/plugin/default-plugins/playground/frontend/components/controls/StringControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/StringControl/index.js
@@ -13,16 +13,14 @@ const StringControl = (props) => {
       value={value}
       isNested={isNested}
       onChange={(e) => onUpdate({ value: e.target.value })}
-      onRandomClick={() => onUpdate({ value: StringControl.randomValue(props) })}
+      onRandomClick={() => onUpdate({ value: StringControl.randomValue(props, props.required) })}
     />
   );
 };
 
-StringControl.randomValue = ({ random = {} }) => {
-  const {
-    canBeNull = true,
-    canBeUndefined = true,
-  } = random;
+StringControl.randomValue = (props, required) => {
+  const canBeUndefined = !required;
+  const canBeNull = !required;
   const randomString = faker.lorem.sentence();
   return valueOrNullOrUndefined(randomString, canBeNull, canBeUndefined);
 };

--- a/plugin/default-plugins/playground/frontend/components/controls/StringControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/StringControl/index.js
@@ -18,9 +18,9 @@ const StringControl = (props) => {
   );
 };
 
-StringControl.randomValue = (props, required) => {
-  const canBeUndefined = !required;
-  const canBeNull = !required;
+StringControl.randomValue = (props) => {
+  const canBeUndefined = !props.required;
+  const canBeNull = !props.required;
   const randomString = faker.lorem.sentence();
   return valueOrNullOrUndefined(randomString, canBeNull, canBeUndefined);
 };

--- a/plugin/default-plugins/playground/frontend/utils/getControl.js
+++ b/plugin/default-plugins/playground/frontend/utils/getControl.js
@@ -19,40 +19,44 @@ import FlowArrayControl from '../components/controls/FlowArrayControl';
 import FlowUnionControl from '../components/controls/FlowUnionControl';
 
 const getControl = (propType) => {
+  const generalProps = {
+    // If something is required, don't randomise it to null/undefined
+    required: propType.required,
+  };
   let control;
   switch (propType.name) {
     case 'bool': // proptypes boolean
-      control = <BooleanControl />;
+      control = <BooleanControl {...generalProps} />;
       break;
     case 'boolean': // flow boolean
-      control = <BooleanControl />;
+      control = <BooleanControl {...generalProps} />;
       break;
     case 'number':
-      control = <IntegerControl />;
+      control = <IntegerControl {...generalProps} />;
       break;
     case 'string':
-      control = <StringControl />;
+      control = <StringControl {...generalProps} />;
       break;
     case 'enum':
-      control = <EnumControl propTypeData={propType} />;
+      control = <EnumControl propTypeData={propType} {...generalProps} />;
       break;
     case 'node':
-      control = <NodeControl />;
+      control = <NodeControl {...generalProps} />;
       break;
     case 'shape': // proptypes
-      control = <ObjectControl propTypeData={propType} />;
+      control = <ObjectControl propTypeData={propType} {...generalProps} />;
       break;
     case 'signature': // flow
-      control = <FlowObjectControl propTypeData={propType} />;
+      control = <FlowObjectControl propTypeData={propType} {...generalProps} />;
       break;
     case 'arrayOf':
-      control = <ArrayControl propTypeData={propType} />;
+      control = <ArrayControl propTypeData={propType} {...generalProps} />;
       break;
     case 'Array':
-      control = <FlowArrayControl propTypeData={propType} />;
+      control = <FlowArrayControl propTypeData={propType} {...generalProps} />;
       break;
     case 'union':
-      control = <FlowUnionControl propTypeData={propType} />;
+      control = <FlowUnionControl propTypeData={propType} {...generalProps} />;
       break;
     default:
       control = <DummyControl />;

--- a/plugin/default-plugins/playground/frontend/utils/randomValues.js
+++ b/plugin/default-plugins/playground/frontend/utils/randomValues.js
@@ -9,7 +9,7 @@ import mapValues from 'lodash/mapValues';
 
 const randomValues = (propTypes) => (
   mapValues(propTypes, (propType) => (
-    propType.control.type.randomValue(propType)
+    propType.control.type.randomValue(propType, propType.required)
   ))
 );
 

--- a/plugin/default-plugins/playground/frontend/utils/valueOrNullOrUndefined.js
+++ b/plugin/default-plugins/playground/frontend/utils/valueOrNullOrUndefined.js
@@ -9,9 +9,9 @@
  */
 const valueOrNullOrUndefined = (value, canBeNull, canBeUndefined) => {
   const random = Math.random();
-  if (canBeNull && random < 0.05) {
+  if (canBeNull && random < 0.025) {
     return null;
-  } else if (canBeUndefined && random > 0.95) {
+  } else if (canBeUndefined && random > 0.975) {
     return undefined;
   }
 


### PR DESCRIPTION
Previously, even prop types like `PropTypes.string.isRequired` generated `null` and `undefined` on random generation, which they shouldn't.

This is a RFC because I'm not sure the signature for the `randomValues` function makes sense. I changed it to:

```JS
Control.randomValue = (props) { /* … */ }
/* …or, for Array and Object controls… */
Control.randomValue = (propTypeValue) { /* … */ }
```

This `props`/`propTypeValue` argument has an `required` property, which is injected in `utils/getControls.js` for each component.
Every control is aware of the fact that it can or cannot generate null or undefined. This should be overrideable in the admin interface, which is why I still re-determine it on every `randomValue()` call.

Maybe it makes more sense to change the function signature to `randomValue = (someObject)`, which would allow us to pass more advanced options in there too. (like min/max for numbers, number type,…)

What do you think?