### PR TITLE
Component styling injection

### DIFF
--- a/client/components/Navigation/index.js
+++ b/client/components/Navigation/index.js
@@ -5,15 +5,18 @@
 
 import React from 'react';
 import { hashHistory, IndexLink } from 'react-router';
-import offsetTopFromPage from './offsetTopFromPage';
-import getComponentNameFromPath from '../../../utils/getComponentNameFromPath';
-import styles from './styles.css';
 import map from 'lodash/map';
 import has from 'lodash/has';
 import throttle from 'lodash/throttle';
 import find from 'lodash/find';
 import flatten from 'lodash/flatten';
+
 import smoothscroll from './smoothscroll';
+import offsetTopFromPage from './offsetTopFromPage';
+import getComponentNameFromPath from '../../../utils/getComponentNameFromPath';
+import getStylingNodes from '../../../utils/getStylingNodes';
+
+import styles from './styles.css';
 
 window.hashHistory = hashHistory;
 
@@ -73,6 +76,13 @@ class Navigation extends React.Component {
     }
   };
 
+  clearStyleNodes = () => {
+    const componentStylingNodes = getStylingNodes();
+    map(componentStylingNodes, (stylingNode) => {
+      stylingNode.parentNode.removeChild(stylingNode);
+    });
+  };
+
   renderSubNavigation = (componentPath) => {
     if (this.props.activeComponentPath === componentPath) {
       if (has(window.STYLEGUIDE_PLUGIN_CLIENT_API.cache, componentPath)) {
@@ -118,6 +128,7 @@ class Navigation extends React.Component {
             <div key={componentPath} >
               <IndexLink
                 to={`/${componentPath}`}
+                onClick={this.clearStyleNodes}
                 className={styles.listItem}
                 activeClassName={styles.listItemActive}
               >

--- a/plugin/default-plugins/playground/frontend/components/Playground/index.js
+++ b/plugin/default-plugins/playground/frontend/components/Playground/index.js
@@ -7,6 +7,7 @@
 import React, { PropTypes } from 'react';
 import { VelocityComponent } from 'velocity-react';
 import Frame from 'react-frame-component';
+import map from 'lodash/map';
 
 import EditButton from '../common/EditButton';
 import DeleteButton from '../common/DeleteButton';
@@ -119,7 +120,9 @@ class Playground extends React.Component {
             initialContent={`
               <!DOCTYPE html>
               <html style="height: 100%; width: 100%; margin: 0; padding: 0;">
-                <head></head>
+                <head>
+                  ${map(this.props.stylingNodes, (styleNode) => styleNode.outerHTML).join('')}
+                </head>
                 <body style="height: 100%; width: 100%; margin: 0; padding: 0;">
                   <div
                     id="root"
@@ -153,6 +156,7 @@ Playground.propTypes = {
   fullHeight: PropTypes.bool,
   variationPath: PropTypes.string.isRequired,
   title: PropTypes.string,
+  stylingNodes: PropTypes.array,
 };
 
 export default Playground;

--- a/plugin/default-plugins/playground/frontend/components/PlaygroundList/index.js
+++ b/plugin/default-plugins/playground/frontend/components/PlaygroundList/index.js
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 import map from 'lodash/map';
 import mapValues from 'lodash/mapValues';
 import find from 'lodash/find';
-import filter from 'lodash/filter';
 import debounce from 'lodash/debounce';
 import 'whatwg-fetch';
 import getSlug from 'speakingurl';
@@ -18,6 +17,7 @@ import variationsToProps from '../../utils/variationsToProps';
 import codeToCustomMetadata from '../../utils/codeToCustomMetadata';
 import customMetadataToCode from '../../utils/customMetadataToCode';
 import getComponentNameFromPath from '../../../../../../utils/getComponentNameFromPath';
+import getStylingNodes from '../../../../../../utils/getStylingNodes';
 
 import Playground from '../Playground';
 import PropForm from '../PropForm';
@@ -28,7 +28,6 @@ import CustomMetadataForm from '../CustomMetadataForm';
 import styles from './styles.css';
 
 const PERSISTENCE_DELAY = 1000;
-const STYLE_TAGS_OF_INTERFACE = 3;
 
 class PlaygroundList extends Component {
   state = {
@@ -309,16 +308,7 @@ class PlaygroundList extends Component {
       );
     // Get all the styling of the components. These tags are injected by style-loader
     // and we can grab all of them and inject them into each iframe of the variations
-    const stylingNodes = document.querySelectorAll('link[rel=stylesheet], style');
-    // Discard STYLE_TAGS_OF_INTERFACE amount of <style> tags, they style the interface
-    let filteredStylingNodes = 0;
-    const userStylingNodes = filter(stylingNodes, (styleNode) => {
-      if (styleNode.nodeName === 'STYLE' && filteredStylingNodes <= STYLE_TAGS_OF_INTERFACE) {
-        filteredStylingNodes++;
-        return false;
-      }
-      return true;
-    });
+    const userStylingNodes = getStylingNodes();
     return (
       <div className={styles.wrapper}>
         <h2 className={styles.title}>

--- a/utils/getStylingNodes.js
+++ b/utils/getStylingNodes.js
@@ -1,0 +1,31 @@
+/* eslint-disable no-var, vars-on-top */
+
+var filter = require('lodash/filter');
+
+var NUMBER_OF_STYLE_TAGS_BY_INTERFACE = 3;
+
+/**
+ * Returns all styling related notes on the page. If the first argument is set
+ * to true, it only returns those that style the interface, if it is set to false
+ * it only returns those that style the rendered components.
+ *
+ * @param  {bool} interfaceStyleTags
+ * @return {array}                       The wanted style nodes
+ */
+var getStylingNodes = (interfaceStyleTags = false) => {
+  // Get all the styling of the components. These tags are injected by style-loader
+  // and we can grab all of them and inject them into each iframe of the variations
+  var stylingNodes = document.querySelectorAll('link[rel=stylesheet], style');
+  // Discard or keep NUMBER_OF_STYLE_TAGS_BY_INTERFACE amount of <style> tags
+  var filteredStylingNodes = 0;
+  return filter(stylingNodes, (stylingNode) => {
+    if (stylingNode.nodeName === 'STYLE'
+        && filteredStylingNodes <= NUMBER_OF_STYLE_TAGS_BY_INTERFACE) {
+      filteredStylingNodes++;
+      return interfaceStyleTags;
+    }
+    return !interfaceStyleTags;
+  });
+};
+
+module.exports = getStylingNodes;


### PR DESCRIPTION
Component styling injection works now! :fire:

There's one problem with it, everytime you go to a new component the style tags of that component are added, but **the old style tags are not removed**. I.e. after a while you end up with 100000s of style tags in a) the DOM and b) all the iFrames, which doesn't seem very healthy:

![screen shot 2016-05-22 at 21 36 56](https://cloud.githubusercontent.com/assets/7525670/15456056/57cd595a-2065-11e6-882a-db0ac7d5a44b.png)
 
_This was taken after clicking back and forth between the Button and the ImmutableList about 5 times_