### PR TITLE
Proper component cards resizing

### DIFF
--- a/plugin/default-plugins/playground/frontend/components/Playground/index.js
+++ b/plugin/default-plugins/playground/frontend/components/Playground/index.js
@@ -42,12 +42,15 @@ class Playground extends React.Component {
     // FIXME: access frame and card through refs! currently not possible because of this issue:
     // https://github.com/pure-ui/styleguide/issues/126
     const element = reactDOM.findDOMNode(this);
-    const frame = element.querySelector('iframe');
-    const card = element.querySelector('[class^=card__]');
 
-    // This seems to be the most accurate methode to calculate the real iframe height
-    const frameHeight = frame.contentDocument.querySelector('#root > div').scrollHeight;
-    card.style.height = `${frameHeight}px`;
+    if (element) {
+      const frame = element.querySelector('iframe');
+      const card = element.querySelector('[class^=card__]');
+
+      // This seems to be the most accurate methode to calculate the real iframe height
+      const frameHeight = frame.contentDocument.querySelector('#root > div').scrollHeight;
+      card.style.height = `${frameHeight}px`;
+    }
   };
 
   showButtons = () => {

--- a/plugin/default-plugins/playground/frontend/components/Playground/index.js
+++ b/plugin/default-plugins/playground/frontend/components/Playground/index.js
@@ -48,8 +48,10 @@ class Playground extends React.Component {
       const card = element.querySelector('[class^=card__]');
 
       // This seems to be the most accurate methode to calculate the real iframe height
-      const frameHeight = frame.contentDocument.querySelector('#root > div').scrollHeight;
-      card.style.height = `${frameHeight}px`;
+      if (frame && card) {
+        const frameHeight = frame.contentDocument.querySelector('#root > div').scrollHeight;
+        card.style.height = `${frameHeight}px`;
+      }
     }
   };
 

--- a/plugin/default-plugins/playground/frontend/components/Playground/index.js
+++ b/plugin/default-plugins/playground/frontend/components/Playground/index.js
@@ -9,6 +9,8 @@ import { VelocityComponent } from 'velocity-react';
 import Frame from 'react-frame-component';
 import map from 'lodash/map';
 
+import reactDOM from 'react-dom';
+
 import EditButton from '../common/EditButton';
 import DeleteButton from '../common/DeleteButton';
 import Card from '../common/Card';
@@ -20,12 +22,32 @@ class Playground extends React.Component {
     delay: true,
   };
 
+  componentDidMount = () => {
+    this.resizeCard();
+  };
+
+  componentDidUpdate = () => {
+    this.resizeCard();
+  };
+
   onEditButtonClick = () => {
     this.props.onEditButtonClick(this.props.variationPath);
   };
 
   onDeleteButtonClick = () => {
     this.props.onDeleteButtonClick(this.props.variationPath);
+  };
+
+  resizeCard = () => {
+    // FIXME: access frame and card through refs! currently not possible because of this issue:
+    // https://github.com/pure-ui/styleguide/issues/126
+    const element = reactDOM.findDOMNode(this);
+    const frame = element.querySelector('iframe');
+    const card = element.querySelector('[class^=card__]');
+
+    // This seems to be the most accurate methode to calculate the real iframe height
+    const frameHeight = frame.contentDocument.querySelector('#root > div').scrollHeight;
+    card.style.height = `${frameHeight}px`;
   };
 
   showButtons = () => {

--- a/plugin/default-plugins/playground/frontend/components/Playground/styles.css
+++ b/plugin/default-plugins/playground/frontend/components/Playground/styles.css
@@ -11,13 +11,11 @@
 
 .wrapper--fullHeight {
   composes: wrapper;
-  height: 100%;
   border: none;
   margin: 0 auto;
 }
 
 .card {
-  height: 100%;
   width: 90%;
   display: flex;
   justify-content: center;
@@ -47,7 +45,6 @@
   width: 100%;
   height: 100%;
   position: absolute;
-  height: 100%;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
@mxstbr @nikgraf have a look at my first pretty straight forward implementation.  i think there is not much to explain.

i used a dirty workaround to access the `Frame` and `Card` element because refs dont work (https://github.com/pure-ui/styleguide/issues/126). once they work we should replace the `reactDOM.findDOMNode(this)` thing.