### PR TITLE
Make hostname and port option of ReactPlugin work

### DIFF
--- a/examples/dev/webpack.dev.babel.js
+++ b/examples/dev/webpack.dev.babel.js
@@ -4,7 +4,7 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import StyleguidePlugin from '../../plugin/styleguide-plugin';
 import autoprefixer from 'autoprefixer';
 
-// import SourcePlugin from '../../plugin/default-plugins/source/plugin';
+import ReactPlugin from '../../plugin/default-plugins/playground/plugin';
 
 export default {
   devtool: 'inline-source-map',
@@ -35,9 +35,9 @@ export default {
         // match components like Button.js
         'src/components/**/[A-Z][a-zA-Z]*.js',
       ],
-      // plugins: [
-      //   new SourcePlugin(),
-      // ],
+      plugins: [
+        new ReactPlugin(),
+      ],
     }),
   ],
   module: {

--- a/plugin/default-plugins/playground/frontend/components/PlaygroundList/index.js
+++ b/plugin/default-plugins/playground/frontend/components/PlaygroundList/index.js
@@ -91,7 +91,7 @@ class PlaygroundList extends Component {
   // Fetch the metadata of the current component
   fetchMetadata = () => {
     // TODO dynamic host
-    fetch(`http://localhost:8000/components/${this.props.componentPath}`)
+    fetch(`http://${this.props.hostname}:${this.props.port}/components/${this.props.componentPath}`)
       .then((response) => response.json())
       .then((json) => {
         const customMetadata = codeToCustomMetadata(json.data);
@@ -131,7 +131,7 @@ class PlaygroundList extends Component {
   // Connect to the socket server
   connectToSocket = () => {
     // TODO dynamic host
-    this.socket = io.connect('http://localhost:8000');
+    this.socket = io.connect(`http://${this.props.hostname}:${this.props.port}`);
     // Listen to the events dispatched by the socket server
     this.socket.on('componentMetadataChanged', this.fetchMetadata);
     this.socket.on('componentVariationChanged', this.fetchVariations);
@@ -149,7 +149,7 @@ class PlaygroundList extends Component {
   // Fetch all variations for the current component
   fetchVariations = () => {
     // TODO dynamic host
-    fetch(`http://localhost:8000/variations/${this.props.componentPath}`)
+    fetch(`http://${this.props.hostname}:${this.props.port}/variations/${this.props.componentPath}`)
       .then((response) => response.json())
       .then((json) => {
         const variationPropsList = variationsToProps(json.data);
@@ -192,7 +192,7 @@ class PlaygroundList extends Component {
       name,
     });
     // TODO dynamic host
-    fetch(`http://localhost:8000/variations/${this.props.componentPath}`, {
+    fetch(`http://${this.props.hostname}:${this.props.port}/variations/${this.props.componentPath}`, {
       method: 'POST',
       headers: {
         Accept: 'application/json',
@@ -213,7 +213,7 @@ class PlaygroundList extends Component {
   };
 
   deleteVariation = (variationPath) => {
-    fetch(`http://localhost:8000/variations/${this.props.componentPath}?variation=${variationPath}`, {
+    fetch(`http://${this.props.hostname}:${this.props.port}/variations/${this.props.componentPath}?variation=${variationPath}`, {
       method: 'DELETE',
       headers: {
         Accept: 'application/json',
@@ -237,7 +237,7 @@ class PlaygroundList extends Component {
       props,
       name: this.state.variationPropsList[variationPath].name,
     });
-    fetch(`http://localhost:8000/variations/${this.props.componentPath}`, {
+    fetch(`http://${this.props.hostname}:${this.props.port}/variations/${this.props.componentPath}`, {
       method: 'POST',
       headers: {
         Accept: 'application/json',
@@ -269,7 +269,7 @@ class PlaygroundList extends Component {
   };
 
   persistCustomMetadata = (customMetadata) => {
-    fetch(`http://localhost:8000/components/${this.props.componentPath}`, {
+    fetch(`http://${this.props.hostname}:${this.props.port}/components/${this.props.componentPath}`, {
       method: 'POST',
       headers: {
         Accept: 'application/json',

--- a/plugin/default-plugins/playground/frontend/index.js
+++ b/plugin/default-plugins/playground/frontend/index.js
@@ -5,6 +5,8 @@ import normalizeMetaInfo from './utils/normalizeMetaInfo';
 export default function playground(options, data, Component, componentPath) {
   return (
     <PlaygroundList
+      hostname={options.hostname}
+      port={options.port}
       componentPath={componentPath}
       component={Component}
       meta={normalizeMetaInfo(data.reactDocs)}

--- a/plugin/default-plugins/playground/plugin.js
+++ b/plugin/default-plugins/playground/plugin.js
@@ -10,7 +10,11 @@ function PlaygroundPlugin(options) {
  * Initializes the plugin, called after the main StyleguidePlugin function above
  */
 PlaygroundPlugin.prototype.apply = function apply(compiler) {
-  const options = this.options;
+  // Default options
+  const options = {
+    hostname: (this.options && this.options.hostname) || 'localhost',
+    port: (this.options && this.options.port) || 8000,
+  };
   const projectBasePath = compiler.options.context;
 
   fork(path.resolve(__dirname, './server/run.js'), [

--- a/plugin/default-plugins/playground/plugin.js
+++ b/plugin/default-plugins/playground/plugin.js
@@ -13,7 +13,10 @@ PlaygroundPlugin.prototype.apply = function apply(compiler) {
   const options = this.options;
   const projectBasePath = compiler.options.context;
 
-  fork(path.resolve(__dirname, './server/run.js'), [projectBasePath]);
+  fork(path.resolve(__dirname, './server/run.js'), [
+    projectBasePath, // process.argv[2]
+    JSON.stringify(options), // process.argv[3]
+  ]);
 
   compiler.plugin('compilation', (compilation) => {
     // Expose the react parse result to all other styleguide plugins

--- a/plugin/default-plugins/playground/server/__test__/server.js
+++ b/plugin/default-plugins/playground/server/__test__/server.js
@@ -4,10 +4,11 @@ import { expect } from 'chai';
 import fs from 'fs';
 import rimraf from 'rimraf';
 
+const hostname = 'localhost';
 const port = 8003;
 const projectBasePath = __dirname;
 const variationsBasePath = path.join(__dirname, 'variations');
-const request = supertest.agent(`http://localhost:${port}`);
+const request = supertest.agent(`http://${hostname}:${port}`);
 
 describe('server', () => {
   let server;
@@ -15,7 +16,10 @@ describe('server', () => {
   beforeEach(() => {
     delete require.cache[require.resolve('./server')];
     server = require('../server'); // eslint-disable-line global-require
-    server.start(projectBasePath, variationsBasePath, port);
+    server.start(projectBasePath, variationsBasePath, {
+      port,
+      hostname,
+    });
   });
 
   afterEach((done) => {

--- a/plugin/default-plugins/playground/server/run.js
+++ b/plugin/default-plugins/playground/server/run.js
@@ -3,15 +3,11 @@
 var server = require('./server');
 var path = require('path');
 var projectBasePath = process.argv[2];
-var options = (process.argv[3] && JSON.parse(process.argv[3])) || {};
-
-// Default options
-var hostname = options.hostname || 'localhost';
-var port = options.port || 8000;
+var options = JSON.parse(process.argv[3]);
 
 // TODO allow to overwrite the path where all the variations data is stored
 server.start(projectBasePath, path.join(projectBasePath, 'variations'), {
-  hostname: hostname,
-  port: port,
+  hostname: options.hostname,
+  port: options.port,
 });
-console.log('\nPlayground Server listening at ' + hostname + ':' + port + '\n');
+console.log('\nPlayground Server listening at ' + options.hostname + ':' + options.port + '\n');

--- a/plugin/default-plugins/playground/server/run.js
+++ b/plugin/default-plugins/playground/server/run.js
@@ -1,10 +1,17 @@
 /* eslint-disable */
 
 var server = require('./server');
-var port = 8000;
 var path = require('path');
 var projectBasePath = process.argv[2];
+var options = (process.argv[3] && JSON.parse(process.argv[3])) || {};
+
+// Default options
+var hostname = options.hostname || 'localhost';
+var port = options.port || 8000;
 
 // TODO allow to overwrite the path where all the variations data is stored
-server.start(projectBasePath, path.join(projectBasePath, 'variations'), port);
-console.log('\nPlayground Server listening to port: ' + port + '\n');
+server.start(projectBasePath, path.join(projectBasePath, 'variations'), {
+  hostname: hostname,
+  port: port,
+});
+console.log('\nPlayground Server listening at ' + hostname + ':' + port + '\n');

--- a/plugin/default-plugins/playground/server/server.js
+++ b/plugin/default-plugins/playground/server/server.js
@@ -28,8 +28,10 @@ var fileExists = (path) => {
 var getRelativeCompPathFromVariations = (req) => req.params[0].replace(/^\/variations/, '');
 var getRelativeCompPathFromComponents = (req) => req.params[0].replace(/^\/components/, '');
 
-var start = (projectBasePath, variationsBasePath, port) => {
+var start = (projectBasePath, variationsBasePath, options) => {
   var app = express();
+  var port = options.port;
+  var hostname = options.hostname;
 
   app.use(cors());
 
@@ -226,7 +228,7 @@ var start = (projectBasePath, variationsBasePath, port) => {
     res.status(200).send(`POST`);
   });
 
-  server = app.listen(port);
+  server = app.listen(port, hostname);
   var io = require('socket.io')(server);
 }
 

--- a/plugin/meta-loader.js
+++ b/plugin/meta-loader.js
@@ -46,7 +46,7 @@ module.exports = function metaLoader(source) {
           return (require(${JSON.stringify(styleguidePlugin.frontendPlugin)}))
             .default.apply(
               this,
-              Array.prototype.concat.apply([this.result, data], arguments)
+              Array.prototype.concat.apply([this.result.options, data], arguments)
             )
         }`;
         return `{

--- a/plugin/styleguide-plugin.js
+++ b/plugin/styleguide-plugin.js
@@ -54,8 +54,11 @@ StyleguidePlugin.prototype.getCache = function getCache(compiler) {
  * Initializes the plugin, called after the main StyleguidePlugin function above
  */
 StyleguidePlugin.prototype.apply = function apply(compiler) {
-  this.registerDefaultPlugins(compiler);
-  this.registerPlugins(compiler);
+  if (this.options.plugins && this.options.plugins.length > 0) {
+    this.registerPlugins(compiler);
+  } else {
+    this.registerDefaultPlugins(compiler);
+  }
 
   // Create the cache for this instace of the compiler
   const cache = this.getCache(compiler);


### PR DESCRIPTION
You can now start the ReactPlugin on different hostnames and ports:

```JS
new ReactPlugin({
  port: 6500,
  hostname: 'example.com',
})
```