### PR TITLE
Show original propType in PropForm

### DIFF
--- a/plugin/default-plugins/playground/frontend/components/common/Input/index.js
+++ b/plugin/default-plugins/playground/frontend/components/common/Input/index.js
@@ -13,6 +13,14 @@ function Input(props) {
   }
   return (
     <div className={wrapperClassname}>
+      {(props.secondaryLabel) && (
+        <Label
+          text={props.secondaryLabel}
+          isNested={props.isNested}
+          onRandomClick={props.onRandomClick}
+          secondary
+        />
+      )}
       {(props.label) && (
         <Label
           text={props.label}
@@ -32,6 +40,7 @@ function Input(props) {
 
 Input.propTypes = {
   label: PropTypes.string,
+  secondaryLabel: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   onRandomClick: PropTypes.func,
   value: PropTypes.any,

--- a/plugin/default-plugins/playground/frontend/components/common/Label/index.js
+++ b/plugin/default-plugins/playground/frontend/components/common/Label/index.js
@@ -6,11 +6,11 @@ import styles from './styles.css';
 function Label(props) {
   return (
     <label
-      className={styles.label}
+      className={props.secondary ? styles['label--secondary'] : styles.label}
       htmlFor={props.text}
     >
       {props.text}
-      {(props.onRandomClick) && (
+      {(props.onRandomClick && !props.secondary) && (
         <RandomButton onClick={props.onRandomClick} />
       )}
     </label>
@@ -19,6 +19,7 @@ function Label(props) {
 
 Label.propTypes = {
   text: PropTypes.string,
+  secondary: PropTypes.bool,
   onRandomClick: PropTypes.func,
 };
 

--- a/plugin/default-plugins/playground/frontend/components/common/Label/styles.css
+++ b/plugin/default-plugins/playground/frontend/components/common/Label/styles.css
@@ -3,7 +3,7 @@
   margin: 0px;
   z-index: 1;
   font-size: 0.8em;
-  color: #999;
+  color: #333;
   font-weight: 400;
   cursor: text;
 }
@@ -11,4 +11,11 @@
 .label--array {
   composes: label;
   padding-bottom: 20px;
+}
+
+.label--secondary {
+  composes: label;
+  color: #999;
+  font-size: 0.6em;
+  display: block;
 }

--- a/plugin/default-plugins/playground/frontend/components/common/Select/index.js
+++ b/plugin/default-plugins/playground/frontend/components/common/Select/index.js
@@ -13,6 +13,14 @@ function Select(props) {
         inputStyles.wrapper
       }
     >
+      {(props.secondaryLabel) && (
+        <Label
+          text={props.secondaryLabel}
+          isNested={props.isNested}
+          onRandomClick={props.onRandomClick}
+          secondary
+        />
+      )}
       <Label
         text={props.label}
         isNested={props.isNested}

--- a/plugin/default-plugins/playground/frontend/components/controls/advanced/AvatarControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/advanced/AvatarControl/index.js
@@ -4,7 +4,7 @@ import Input from '../../../common/Input';
 import randomValue from './randomValue';
 
 const AvatarControl = (props) => {
-  const { label, value, onUpdate, isNested } = props;
+  const { label, value, onUpdate, isNested, secondaryLabel } = props;
   return (
     <Input
       value={value}
@@ -12,6 +12,7 @@ const AvatarControl = (props) => {
       isNested={isNested}
       onChange={(data) => onUpdate({ value: data.value })}
       label={label}
+      secondaryLabel={secondaryLabel}
       onRandomClick={() => onUpdate({ value: AvatarControl.randomValue(props) })}
     />
   );

--- a/plugin/default-plugins/playground/frontend/components/controls/advanced/NameControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/advanced/NameControl/index.js
@@ -5,7 +5,7 @@ import ConstraintsForm from './ConstraintsForm';
 import randomValue from './randomValue';
 
 const NameControl = (props) => {
-  const { label, value, onUpdate, isNested } = props;
+  const { label, value, onUpdate, isNested, secondaryLabel } = props;
   return (
     <Input
       value={value}
@@ -13,6 +13,7 @@ const NameControl = (props) => {
       isNested={isNested}
       onChange={(data) => onUpdate({ value: data.value })}
       label={label}
+      secondaryLabel={secondaryLabel}
       onRandomClick={() => onUpdate({ value: NameControl.randomValue(props) })}
     />
   );

--- a/plugin/default-plugins/playground/frontend/components/controls/base/BooleanControl/__test__/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/base/BooleanControl/__test__/index.js
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import BooleanControl from '../index';
 
 const label = 'a boolean control';
+const secondaryLabel = 'secondary';
 const onUpdate = sinon.spy();
 const value = true;
 let props;
@@ -12,12 +13,16 @@ let wrapper;
 
 describe('<BooleanControl />', () => {
   beforeEach(() => {
-    props = { label, onUpdate, value };
+    props = { label, onUpdate, value, secondaryLabel };
     wrapper = mount(<BooleanControl {...props} />);
   });
 
   it('should render label prop', () => {
     expect(wrapper.text()).to.contain(label);
+  });
+
+  it('should render secondary label prop', () => {
+    expect(wrapper.text()).to.contain(secondaryLabel);
   });
 
   it('should call onUpdate() when clicking on random', () => {

--- a/plugin/default-plugins/playground/frontend/components/controls/base/BooleanControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/base/BooleanControl/index.js
@@ -9,10 +9,11 @@ import Select from '../../../common/Select';
 import randomValue from './randomValue';
 
 const BooleanControl = (props) => {
-  const { label, value, onUpdate } = props;
+  const { label, value, onUpdate, secondaryLabel } = props;
   return (
     <Select
       label={label}
+      secondaryLabel={secondaryLabel}
       onChange={(event) => {
         // Need to eval, because we're getting 'true' and 'false' (strings)
         // instead of true and false (booleans) here

--- a/plugin/default-plugins/playground/frontend/components/controls/base/EnumControl/__test__/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/base/EnumControl/__test__/index.js
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import EnumControl from '../index';
 
 const label = 'enum control';
+const secondaryLabel = 'secondary';
 const onUpdate = sinon.spy();
 const propTypeData = {
   description: '',
@@ -22,12 +23,16 @@ let wrapper;
 
 describe('<EnumControl />', () => {
   beforeEach(() => {
-    props = { label, onUpdate, value, propTypeData };
+    props = { label, onUpdate, value, propTypeData, secondaryLabel };
     wrapper = mount(<EnumControl {...props} />);
   });
 
   it('should render label prop', () => {
     expect(wrapper.text()).to.contain(label);
+  });
+
+  it('should render secondary label prop', () => {
+    expect(wrapper.text()).to.contain(secondaryLabel);
   });
 
   it('should render all options', () => {

--- a/plugin/default-plugins/playground/frontend/components/controls/base/EnumControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/base/EnumControl/index.js
@@ -11,6 +11,7 @@ import randomValue from './randomValue';
 const EnumControl = (props) => {
   const {
     label,
+    secondaryLabel,
     value,
     propTypeData,
     onUpdate,
@@ -18,6 +19,7 @@ const EnumControl = (props) => {
   return (
     <Select
       label={label}
+      secondaryLabel={secondaryLabel}
       value={value}
       onChange={(event) => {
         const newValue = event.target.value;

--- a/plugin/default-plugins/playground/frontend/components/controls/base/FunctionControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/base/FunctionControl/index.js
@@ -6,9 +6,9 @@
 
 import React from 'react';
 
-const FunctionControl = ({ label }) => (
+const FunctionControl = ({ label, secondaryLabel }) => (
   <div>
-    {label} - function
+    {label} - {secondaryLabel} - function
   </div>
 );
 

--- a/plugin/default-plugins/playground/frontend/components/controls/base/IntegerControl/__test__/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/base/IntegerControl/__test__/index.js
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import IntegerControl from '../index';
 
 const label = 'integer-control';
+const secondaryLabel = 'secondary';
 const onUpdate = sinon.spy();
 const value = 1;
 let props;
@@ -12,12 +13,16 @@ let wrapper;
 
 describe('<IntegerControl />', () => {
   beforeEach(() => {
-    props = { label, onUpdate, value, isNested: false };
+    props = { label, onUpdate, value, isNested: false, secondaryLabel };
     wrapper = mount(<IntegerControl {...props} />);
   });
 
   it('should render label prop', () => {
     expect(wrapper.text()).to.contain(label);
+  });
+
+  it('should render secondary label prop', () => {
+    expect(wrapper.text()).to.contain(secondaryLabel);
   });
 
   it('should render initial value', () => {

--- a/plugin/default-plugins/playground/frontend/components/controls/base/IntegerControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/base/IntegerControl/index.js
@@ -10,10 +10,11 @@ import randomValue from './randomValue';
 import Input from '../../../common/Input';
 
 const IntegerControl = (props) => {
-  const { label, value, onUpdate, isNested } = props;
+  const { label, value, onUpdate, isNested, secondaryLabel } = props;
   return (
     <Input
       label={label}
+      secondaryLabel={secondaryLabel}
       type="number"
       step="1"
       value={value}

--- a/plugin/default-plugins/playground/frontend/components/controls/base/StringControl/__test__/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/base/StringControl/__test__/index.js
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import StringControl from '../index';
 
 const label = 'string-control';
+const secondaryLabel = 'secondary';
 const onUpdate = sinon.spy();
 const value = 'test some string';
 let props;
@@ -12,12 +13,16 @@ let wrapper;
 
 describe('<StringControl />', () => {
   beforeEach(() => {
-    props = { label, onUpdate, value, isNested: false };
+    props = { label, onUpdate, value, isNested: false, secondaryLabel };
     wrapper = mount(<StringControl {...props} />);
   });
 
   it('should render label prop', () => {
     expect(wrapper.text()).to.contain(label);
+  });
+
+  it('should render secondary label prop', () => {
+    expect(wrapper.text()).to.contain(secondaryLabel);
   });
 
   it('should render initial value', () => {

--- a/plugin/default-plugins/playground/frontend/components/controls/base/StringControl/index.js
+++ b/plugin/default-plugins/playground/frontend/components/controls/base/StringControl/index.js
@@ -3,10 +3,11 @@ import randomValue from './randomValue';
 import Input from '../../../common/Input';
 
 const StringControl = (props) => {
-  const { label, value, onUpdate, isNested } = props;
+  const { label, value, onUpdate, isNested, secondaryLabel } = props;
   return (
     <Input
       label={label}
+      secondaryLabel={secondaryLabel}
       type="text"
       value={value}
       isNested={isNested}

--- a/plugin/default-plugins/playground/frontend/utils/renderControls.js
+++ b/plugin/default-plugins/playground/frontend/utils/renderControls.js
@@ -21,6 +21,7 @@ const renderControls = (
   const controls = mapValues(metadataWithControls, (prop, keyPath) => {
     const props = {
       label: keyPath,
+      secondaryLabel: prop.name,
       value: get(globalComponentProps, keyPath),
       onUpdate: ({ value }) => updatePropertyValues(keyPath, value),
       isNested,


### PR DESCRIPTION
The form now shows the original propType in the PropForm UI:

![screen shot 2016-05-28 at 11 44 55](https://cloud.githubusercontent.com/assets/7525670/15626638/16228232-24ca-11e6-90c0-3aa3996953b0.png)

I originally wanted to show `customPropType (originalPropType)` (e.g. `name (node)`), but I don't have access to the name of the chosen control in `renderControls`, which means I can't display it.
Any ideas how to pipe that through are much appreciated, but if not this should be fine!

I also added tests for the new secondary label, but didn't spend too much time tinkering with the styling since that's going to change with #145 anyway.

Closes #133