### PR TITLE
Handle variation parsing errors

### DIFF
--- a/plugins/react/frontend/components/PlaygroundList/index.js
+++ b/plugins/react/frontend/components/PlaygroundList/index.js
@@ -20,6 +20,8 @@ import codeToCustomMetadata from '../../utils/codeToCustomMetadata';
 import customMetadataToCode from '../../utils/customMetadataToCode';
 import addDataToVariation from '../../utils/addDataToVariation';
 import KeyCodes from '../../utils/keycodes';
+import getVariationComponentPath from '../../utils/getVariationComponentPath';
+// Shared Utilities between ReactPlugin and Client
 import getComponentNameFromPath from '../../../../../utils/getComponentNameFromPath';
 import getStylingNodes from '../../../../../utils/getStylingNodes';
 
@@ -417,6 +419,8 @@ class PlaygroundList extends Component {
           variation.err ? (
             <Playground
               key={variationPath}
+              variationPath={variationPath}
+              componentPath={getVariationComponentPath(this.props.componentPath)}
               err={variation.err}
             />
           ) : (

--- a/plugins/react/frontend/components/PlaygroundList/index.js
+++ b/plugins/react/frontend/components/PlaygroundList/index.js
@@ -153,6 +153,7 @@ class PlaygroundList extends Component {
       .then((response) => response.json())
       .then((json) => {
         const variationPropsList = variationsToProps(json.data);
+
         this.setState({
           variationPropsList,
           loadingVariations: false,
@@ -173,7 +174,7 @@ class PlaygroundList extends Component {
       })
       .catch((ex) => {
         // TODO proper error handling
-        console.error('parsing failed', ex); // eslint-disable-line no-console
+        console.error(ex); // eslint-disable-line no-console
       });
   };
 
@@ -413,16 +414,23 @@ class PlaygroundList extends Component {
         </Modal>
         {/* MAIN AREA WITH PLAYGROUNDS */}
         {map(this.state.variationPropsList, (variation, variationPath) => (
-          <Playground
-            key={variationPath}
-            component={component}
-            title={variation.name}
-            variationProps={variation.props}
-            variationPath={variationPath}
-            onDeleteButtonClick={this.deleteVariation}
-            onEditButtonClick={this.startVariationEditMode}
-            stylingNodes={userStylingNodes}
-          />
+          variation.err ? (
+            <Playground
+              key={variationPath}
+              err={variation.err}
+            />
+          ) : (
+            <Playground
+              key={variationPath}
+              component={component}
+              title={variation.name}
+              variationProps={variation.props}
+              variationPath={variationPath}
+              onDeleteButtonClick={this.deleteVariation}
+              onEditButtonClick={this.startVariationEditMode}
+              stylingNodes={userStylingNodes}
+            />
+          )
         ))}
         <CreateVariationButton
           error={this.state.createVariationError}

--- a/plugins/react/frontend/components/common/Playground/index.js
+++ b/plugins/react/frontend/components/common/Playground/index.js
@@ -144,7 +144,11 @@ class Playground extends React.Component {
           {/* Render error or the actual component */}
           {(this.props.err) ? (
             <div className={styles.errWrapper}>
-              <code className={styles.err}>{this.props.err}</code>
+              <code className={styles.err}>
+                {`
+${this.props.err}
+    at ${this.props.componentPath}/${this.props.variationPath}.js`}
+              </code>
             </div>
           ) : (
             <Frame

--- a/plugins/react/frontend/components/common/Playground/index.js
+++ b/plugins/react/frontend/components/common/Playground/index.js
@@ -141,34 +141,39 @@ class Playground extends React.Component {
               </div>
             </VelocityComponent>
           )}
-
-          {/* Render the actual component */}
-          <Frame
-            initialContent={`
-              <!DOCTYPE html>
-              <html style="height: 100%; width: 100%; margin: 0; padding: 0;">
-                <head>
-                  ${map(this.props.stylingNodes, (styleNode) => styleNode.outerHTML).join('')}
-                </head>
-                <body style="height: 100%; width: 100%; margin: 0; padding: 0;">
-                  <div
-                    id="root"
-                    style="
-                      height: 100%;
-                      width: 100%;
-                      display: flex;
-                      justify-content: center;
-                      align-items: center;
-                    "
-                  ></div>
-                </body>
-              </html>
-            `}
-            mountTarget="#root"
-            className={styles.componentFrame}
-          >
-            <Component {...this.props.variationProps} />
-          </Frame>
+          {/* Render error or the actual component */}
+          {(this.props.err) ? (
+            <div className={styles.errWrapper}>
+              <code className={styles.err}>{this.props.err}</code>
+            </div>
+          ) : (
+            <Frame
+              initialContent={`
+                <!DOCTYPE html>
+                <html style="height: 100%; width: 100%; margin: 0; padding: 0;">
+                  <head>
+                    ${map(this.props.stylingNodes, (styleNode) => styleNode.outerHTML).join('')}
+                  </head>
+                  <body style="height: 100%; width: 100%; margin: 0; padding: 0;">
+                    <div
+                      id="root"
+                      style="
+                        height: 100%;
+                        width: 100%;
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;
+                      "
+                    ></div>
+                  </body>
+                </html>
+              `}
+              mountTarget="#root"
+              className={styles.componentFrame}
+            >
+              <Component {...this.props.variationProps} />
+            </Frame>
+          )}
         </Card>
       </div>
     );
@@ -176,12 +181,13 @@ class Playground extends React.Component {
 }
 
 Playground.propTypes = {
-  variationProps: PropTypes.object.isRequired,
-  component: PropTypes.func.isRequired, // TODO is this really always a function
+  variationProps: PropTypes.object,
+  component: PropTypes.func, // TODO is this really always a function
   onEditButtonClick: PropTypes.func,
+  error: PropTypes.string,
   onDeleteButtonClick: PropTypes.func,
   fullHeight: PropTypes.bool,
-  variationPath: PropTypes.string.isRequired,
+  variationPath: PropTypes.string,
   title: PropTypes.string,
   stylingNodes: PropTypes.array,
 };

--- a/plugins/react/frontend/components/common/Playground/styles.css
+++ b/plugins/react/frontend/components/common/Playground/styles.css
@@ -24,6 +24,27 @@
   margin: 0 auto;
 }
 
+.errWrapper {
+  width: 100%;
+  height: 100%;
+  background-color: rgba(251, 79, 79, 0.75);
+  color: white;
+  padding: 1em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 3px; /* Same as Card component main div */
+}
+
+.err {
+  white-space: pre-wrap;
+}
+
 .title {
   font-size: 1.5em;
   font-weight: 300;

--- a/plugins/react/frontend/utils/__test__/variationsToProps.js
+++ b/plugins/react/frontend/utils/__test__/variationsToProps.js
@@ -328,12 +328,12 @@ describe('variationsToProps', () => {
     it('should handle a function prop', () => {
       const variations = {
         variationA: `{
-    "props": {
-      "onClick": function onClick() {
-          return undefined;
-        }
-    }
-  };`,
+  "props": {
+    "onClick": function onClick() {
+        return undefined;
+      }
+  }
+};`,
       };
       expect(variationsToProps(variations).variationA.props.onClick).to.be.an('function');
     });
@@ -341,16 +341,61 @@ describe('variationsToProps', () => {
     it('should handle a nested function prop', () => {
       const variations = {
         variationA: `{
-    "props": {
-      "hairs": {
-        "onClick": function onClick() {
-            return undefined;
-          }
-      }
+  "props": {
+    "hairs": {
+      "onClick": function onClick() {
+          return undefined;
+        }
     }
-  };`,
+  }
+};`,
       };
       expect(variationsToProps(variations).variationA.props.hairs.onClick).to.be.an('function');
+    });
+  });
+
+  describe('should properly handle errors', () => {
+    it('should handle a parsing error', () => {
+      const variations = {
+        variationA: `{
+  "props": {
+    "hairs": undefinedVariable
+  }
+};`,
+      };
+      const parsedVariations = variationsToProps(variations);
+      expect(parsedVariations.variationA.err).to.exist();
+      // 48 = Length of "ReferenceError: …"
+      expect(parsedVariations.variationA.err).to.have.length.above(48);
+    });
+
+    it('should parse other variations even if parsing error happened', () => {
+      const variations = {
+        variationA: `{
+  "props": {
+    "hairs": undefinedVariable
+  }
+};`,
+        variationB: `{
+  "props": {
+    "hairs": {
+      "length": 4
+    }
+  }
+}`,
+      };
+      const expectedVariationB = {
+        props: {
+          hairs: {
+            length: 4,
+          },
+        },
+      };
+      const parsedVariations = variationsToProps(variations);
+      expect(parsedVariations.variationA.err).to.exist();
+      // 48 = Length of "ReferenceError: …"
+      expect(parsedVariations.variationA.err).to.have.length.above(48);
+      expect(parsedVariations.variationB).to.deep.equal(expectedVariationB);
     });
   });
 });

--- a/plugins/react/frontend/utils/__test__/variationsToProps.js
+++ b/plugins/react/frontend/utils/__test__/variationsToProps.js
@@ -354,7 +354,7 @@ describe('variationsToProps', () => {
     });
   });
 
-  describe('should properly handle errors', () => {
+  describe.only('should properly handle errors', () => {
     it('should handle a parsing error', () => {
       const variations = {
         variationA: `{
@@ -365,8 +365,8 @@ describe('variationsToProps', () => {
       };
       const parsedVariations = variationsToProps(variations);
       expect(parsedVariations.variationA.err).to.exist();
-      // 48 = Length of "ReferenceError: …"
-      expect(parsedVariations.variationA.err).to.have.length.above(48);
+      expect(parsedVariations.variationA.err)
+        .to.equal('ReferenceError: undefinedVariable is not defined');
     });
 
     it('should parse other variations even if parsing error happened', () => {
@@ -393,8 +393,8 @@ describe('variationsToProps', () => {
       };
       const parsedVariations = variationsToProps(variations);
       expect(parsedVariations.variationA.err).to.exist();
-      // 48 = Length of "ReferenceError: …"
-      expect(parsedVariations.variationA.err).to.have.length.above(48);
+      expect(parsedVariations.variationA.err)
+        .to.equal('ReferenceError: undefinedVariable is not defined');
       expect(parsedVariations.variationB).to.deep.equal(expectedVariationB);
     });
   });

--- a/plugins/react/frontend/utils/getVariationComponentPath.js
+++ b/plugins/react/frontend/utils/getVariationComponentPath.js
@@ -1,0 +1,28 @@
+/**
+ * !!!!!COPIED FROM server/getVariationPathFromComponentPath!!!!!
+ */
+
+// Regexes
+
+// TODO make file-ending dynamic
+const FILE_ENDING_REGEX = /\.jsx?|\.es6?/gi;
+const INDEX_PATH_REGEX = /\/index/gi;
+
+/**
+ * Gets the component name from a path
+ *
+ * @param  {string} path The component path, e.g. /folder/components/Button.js
+ * @return {String}      Only the component name, e.g. Button
+ */
+const getVariationPathFromComponentPath = (relativeComponentPath) => {
+  // Step 1: Remove file endinging
+  let variationPath = relativeComponentPath.replace(FILE_ENDING_REGEX, '');
+  // Step 2: Remove file endings and index files
+  const indexPaths = variationPath.match(INDEX_PATH_REGEX);
+  if (indexPaths !== null) {
+    variationPath = variationPath.replace(INDEX_PATH_REGEX, '');
+  }
+  return variationPath;
+};
+
+export default getVariationPathFromComponentPath;

--- a/plugins/react/frontend/utils/variationsToProps.js
+++ b/plugins/react/frontend/utils/variationsToProps.js
@@ -13,7 +13,7 @@ const variationsToProps = (variations) => (
     try {
       eval(`wrapper = ${variationAsCode}`); // eslint-disable-line no-eval
     } catch (err) {
-      wrapper = { err: err.stack };
+      wrapper = { err: err.toString() };
     }
     return wrapper;
   })

--- a/plugins/react/frontend/utils/variationsToProps.js
+++ b/plugins/react/frontend/utils/variationsToProps.js
@@ -10,7 +10,11 @@ const variationsToProps = (variations) => (
     const variationAsCode = variation.replace(MATCH_LAST_SEMICOLON_REGEX, '');
     // Parse the JSON
     let wrapper;
-    eval(`wrapper = ${variationAsCode}`); // eslint-disable-line no-eval
+    try {
+      eval(`wrapper = ${variationAsCode}`); // eslint-disable-line no-eval
+    } catch (err) {
+      wrapper = { err: err.stack };
+    }
     return wrapper;
   })
 );


### PR DESCRIPTION
Properly catch and handle individual variation parsing errors.

The remaining app remains usable, only the variation that the parsing failed of shows a stack trace:

![variation-error](https://cloud.githubusercontent.com/assets/7525670/15629822/d4f5677a-2523-11e6-8000-5e3a6aeb4e1a.gif)
