### PR TITLE
Handle metadata parsing error

### DIFF
--- a/plugins/react/frontend/components/PlaygroundList/index.js
+++ b/plugins/react/frontend/components/PlaygroundList/index.js
@@ -41,6 +41,7 @@ const PERSISTENCE_DELAY = 1000;
 
 class PlaygroundList extends Component {
   state = {
+    metadataError: null,
     variationPropsList: {},
     variationEditMode: false,
     customMetadataEditMode: false,
@@ -97,20 +98,26 @@ class PlaygroundList extends Component {
       .then((response) => response.json())
       .then((json) => {
         const customMetadata = codeToCustomMetadata(json.data);
-        const metadataWithControls = this.generateMetadataWithControls(
-          this.props.meta,
-          customMetadata
-        );
+        if (customMetadata.err) {
+          this.setState({
+            metadataError: customMetadata.err,
+          });
+        } else {
+          const metadataWithControls = this.generateMetadataWithControls(
+            this.props.meta,
+            customMetadata
+          );
 
-        this.setState({
-          metadataWithControls,
-          customMetadata,
-          loadingMetadata: false,
-        });
+          this.setState({
+            metadataWithControls,
+            customMetadata,
+            metadataError: null,
+            loadingMetadata: false,
+          });
+        }
       })
       .catch((ex) => {
-        // TODO proper error handling
-        console.error('meta data parsing failed', ex); // eslint-disable-line no-console
+        console.error('Generating metadata failed', ex); // eslint-disable-line no-console
       });
   };
 
@@ -358,6 +365,17 @@ class PlaygroundList extends Component {
   render() {
     if (this.state.loadingMetadata && this.state.loadingVariations) {
       return <div>Loading …</div>;
+    }
+
+    if (this.state.metadataError) {
+      return (
+        <div className={styles.errWrapper}>
+          <code className={styles.err}>
+            {`${this.state.metadataError}
+    in ${getVariationComponentPath(this.props.componentPath)}/meta.js`}
+          </code>
+        </div>
+      );
     }
 
     const { component } = this.props;

--- a/plugins/react/frontend/components/PlaygroundList/styles.css
+++ b/plugins/react/frontend/components/PlaygroundList/styles.css
@@ -24,21 +24,19 @@
 .errWrapper {
   width: 100%;
   height: 100%;
-  background-color: rgba(251, 79, 79, 0.9);
-  color: white;
+  background-color: rgba(251, 79, 79, 0.75);
   padding: 1em;
   display: flex;
   align-items: center;
   justify-content: center;
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  border-radius: 3px; /* Same as Card component main div */
-  z-index: 2;
 }
 
 .err {
+  color: white;
   white-space: pre-wrap;
 }

--- a/plugins/react/frontend/components/PlaygroundList/styles.css
+++ b/plugins/react/frontend/components/PlaygroundList/styles.css
@@ -20,3 +20,25 @@
   position: relative;
   top: 3px;
 }
+
+.errWrapper {
+  width: 100%;
+  height: 100%;
+  background-color: rgba(251, 79, 79, 0.9);
+  color: white;
+  padding: 1em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 3px; /* Same as Card component main div */
+  z-index: 2;
+}
+
+.err {
+  white-space: pre-wrap;
+}

--- a/plugins/react/frontend/utils/__test__/codeToCustomMetadata.js
+++ b/plugins/react/frontend/utils/__test__/codeToCustomMetadata.js
@@ -21,4 +21,16 @@ describe('codeToCustomMetadata', () => {
     const expected = {};
     expect(codeToCustomMetadata(code)).to.deep.equal(expected);
   });
+
+  it('should catch errors correctly', () => {
+    const code = `{
+  "props": {
+    "age": undefinedVariable
+  }
+};`;
+    const expected = {
+      err: 'SyntaxError: Unexpected token u',
+    };
+    expect(codeToCustomMetadata(code)).to.deep.equal(expected);
+  });
 });

--- a/plugins/react/frontend/utils/__test__/variationsToProps.js
+++ b/plugins/react/frontend/utils/__test__/variationsToProps.js
@@ -354,7 +354,7 @@ describe('variationsToProps', () => {
     });
   });
 
-  describe.only('should properly handle errors', () => {
+  describe('should properly handle errors', () => {
     it('should handle a parsing error', () => {
       const variations = {
         variationA: `{

--- a/plugins/react/frontend/utils/codeToCustomMetadata.js
+++ b/plugins/react/frontend/utils/codeToCustomMetadata.js
@@ -1,7 +1,13 @@
 const MATCH_LAST_SEMICOLON_REGEX = /;\s*$/;
 
-const codeToCustomMetadata = (code) => (
-  JSON.parse(code.replace(MATCH_LAST_SEMICOLON_REGEX, ''))
-);
+const codeToCustomMetadata = (code) => {
+  try {
+    return JSON.parse(code.replace(MATCH_LAST_SEMICOLON_REGEX, ''));
+  } catch (err) {
+    return {
+      err: err.toString(),
+    };
+  }
+};
 
 export default codeToCustomMetadata;


### PR DESCRIPTION
Not only shows the error, also gives a nicely usable stack trace and recovers from errors perfectly fine!

![metadata-error](https://cloud.githubusercontent.com/assets/7525670/15630311/83ef26b0-2535-11e6-8e6e-18ef94150ca0.gif)
